### PR TITLE
Add a support to work as a light bulb

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,10 +17,28 @@ function delaySwitch(log, config, api) {
     this.delay = config['delay'];
     this.disableSensor = config['disableSensor'] || false;
     this.startOnReboot = config['startOnReboot'] || false;
+    this.actAsBulb = config['actAsBulb'] || false;
     this.timer;
     this.switchOn = false;
+    this.brightness = 0;
     this.motionTriggered = false;
     this.uuid = UUIDGen.generate(this.name)
+}
+
+delaySwitch.prototype.createMainService = function (name) {
+    if (this.mainService) return this.mainService;
+    if (this.actAsBulb) return this.createLightBulb(name);
+    return new Service.Switch(name);
+}
+
+delaySwitch.prototype.createLightBulb = function (name) {
+    const service = new Service.Lightbulb(name);
+
+    service.getCharacteristic(Characteristic.Brightness)
+        .on('get', cb => cb(null, this.brightness))
+        .on('set', this.setBrightness.bind(this));
+
+    return service;
 }
 
 delaySwitch.prototype.getServices = function () {
@@ -32,19 +50,18 @@ delaySwitch.prototype.getServices = function () {
         .setCharacteristic(Characteristic.SerialNumber, this.uuid);
 
 
-    this.switchService = new Service.Switch(this.name);
+    this.mainService = this.createMainService(this.name);
 
-
-    this.switchService.getCharacteristic(Characteristic.On)
+    this.mainService.getCharacteristic(Characteristic.On)
         .on('get', this.getOn.bind(this))
         .on('set', this.setOn.bind(this));
 
     if (this.startOnReboot)
-        this.switchService.setCharacteristic(Characteristic.On, true)
-    
-    var services = [informationService, this.switchService]
-    
-    if (!this.disableSensor){
+        this.mainService.setCharacteristic(Characteristic.On, true)
+
+    var services = [informationService, this.mainService]
+
+    if (!this.disableSensor) {
         this.motionService = new Service.MotionSensor(this.name + ' Trigger');
 
         this.motionService
@@ -57,42 +74,73 @@ delaySwitch.prototype.getServices = function () {
 
 }
 
+delaySwitch.prototype.update = function () {
+    const unit = Math.min(Math.floor(this.delay / 1000 / 20), 5);
+    this.timer = setTimeout(() => {
+        this.brightness = (Math.floor(this.brightness / unit) - 1) * unit;
+
+        this.mainService.getCharacteristic(Characteristic.Brightness).updateValue(this.brightness);
+        this.log(`${this.brightness}s remains`);
+
+        if (this.brightness <= 0) {
+            this.timeout();
+        } else {
+            this.update();
+        }
+    }, unit * 1000);
+}
+
+delaySwitch.prototype.setBrightness = function (brightness, callback) {
+    this.log(`Set the Timer with ${brightness}%`);
+    
+    this.brightness = brightness;
+    
+    clearTimeout(this.timer);
+
+    if (0 < brightness) {
+        this.update();
+    }
+
+    callback();
+}
+
+delaySwitch.prototype.timeout = function () {
+    this.log('Time is Up!');
+    this.mainService.getCharacteristic(Characteristic.On).updateValue(false);
+    this.switchOn = false;
+
+    if (!this.disableSensor) {
+        this.motionTriggered = true;
+        this.motionService.getCharacteristic(Characteristic.MotionDetected).updateValue(true);
+        this.log('Triggering Motion Sensor');
+        setTimeout(function () {
+            this.motionService.getCharacteristic(Characteristic.MotionDetected).updateValue(false);
+            this.motionTriggered = false;
+        }.bind(this), 3000);
+    }
+}
 
 delaySwitch.prototype.setOn = function (on, callback) {
-
     if (!on) {
         this.log('Stopping the Timer');
-    
+
         this.switchOn = false;
         clearTimeout(this.timer);
         this.motionTriggered = false;
         if (!this.disableSensor) this.motionService.getCharacteristic(Characteristic.MotionDetected).updateValue(false);
-
-        
-      } else {
+    } else {
         this.log('Starting the Timer');
         this.switchOn = true;
-    
-        clearTimeout(this.timer);
-        this.timer = setTimeout(function() {
-          this.log('Time is Up!');
-          this.switchService.getCharacteristic(Characteristic.On).updateValue(false);
-          this.switchOn = false;
-            
-          if (!this.disableSensor) {
-              this.motionTriggered = true;
-              this.motionService.getCharacteristic(Characteristic.MotionDetected).updateValue(true);
-              this.log('Triggering Motion Sensor');
-              setTimeout(function() {
-                  this.motionService.getCharacteristic(Characteristic.MotionDetected).updateValue(false);
-                  this.motionTriggered = false;
-              }.bind(this), 3000);
-          }
-          
-        }.bind(this), this.delay);
-      }
-    
-      callback();
+
+        if (!this.actAsBulb) {
+            clearTimeout(this.timer);
+            this.timer = setTimeout(function () {
+                this.timeout();
+            }.bind(this), this.delay);
+        }
+    }
+
+    callback();
 }
 
 
@@ -101,6 +149,6 @@ delaySwitch.prototype.getOn = function (callback) {
     callback(null, this.switchOn);
 }
 
-delaySwitch.prototype.getMotion = function(callback) {
+delaySwitch.prototype.getMotion = function (callback) {
     callback(null, this.motionTriggered);
 }


### PR DESCRIPTION
With setting the config property `actAsBulb` as true, a light bulb will be exposed instead of a switch.

<img width="522" alt="image" src="https://user-images.githubusercontent.com/154198/107109813-96cf3380-6886-11eb-95ae-4b28fcdf71c9.png">

It gives users an indication how much time remains until the time's up.

Users can utilize the brightness like a gauge of a specified timer with their automation. Meaning, they have set a timer for an hour, they can choose the percentage of an hour in HomeKit without adjusting the delay in a homebridge.