### PR TITLE
Add lightbulb option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ If you don't use Homebridge UI or HOOBS, keep reading:
 | `accessory`             | always `"DelaySwitch"`               |     ✓    |     -    |  String  |
 | `name`                  | Name for your accessory              |     ✓    |     -    |  String  |
 | `delay`                 |  Delay/Timer in milliseconds         |     ✓    |     -    |  Integer |
+| `actAsBulb`             |  Add lightbulb instead of a switch, that allows setting time by percentage <br>**1% = `delay`** (e.g. `"delay": 60000` means 1% = 1 minute)         |         | `false` |  Boolean |
 | `sensorType`            |  The sensor type that will trigger when the time has ended (`null` for no sensor)         |         | `"motion"` |  Integer |
 | `flipSensorState`       | Flips the trigger sensor state (close/open, detected/not detected)   |          |   `false`  |  Boolean |
 | `startOnReboot`         |  When set to `true`, the switch will be turned ON and start the timer when Homebridge restarts        |       |  `false` |  Boolean  |

--- a/config.schema.json
+++ b/config.schema.json
@@ -20,6 +20,13 @@
                 "default": 5000,
                 "required": true
             },
+            "actAsBulb": {
+                "title": "Add lightbulb instead of a switch",
+                "description": "This allows setting time by percentage when 1% = `delay` (e.g. `\"delay\": 60000` means 1% = 1 minute)",
+                "type": "boolean",
+                "default": false,
+                "required": false
+            },
             "sensorType": {
                 "title": "Trigger Sensor Type",
                 "description": "The sensor type that will trigger when the time has ended (\"None\" for no sensor, \"Motion Sensor\" is default)",

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-
-
 var Service, Characteristic;
 
 module.exports = function (homebridge) {
@@ -7,7 +5,6 @@ module.exports = function (homebridge) {
     Characteristic = homebridge.hap.Characteristic;
     homebridge.registerAccessory("homebridge-delay-switch", "DelaySwitch", delaySwitch);
 }
-
 
 function delaySwitch(log, config, api) {
     let UUIDGen = api.hap.uuid;
@@ -21,10 +18,28 @@ function delaySwitch(log, config, api) {
     this.flipSensor = config['flipSensorState'];
     this.disableSensor = config['disableSensor'] || !config['sensorType'];
     this.startOnReboot = config['startOnReboot'];
+    this.actAsBulb = config['actAsBulb'] || false;
     this.timer;
     this.switchOn = false;
+    this.brightness = 0;
     this.sensorTriggered = 0;
     this.uuid = UUIDGen.generate(this.name)
+
+    delaySwitch.prototype.createMainService = function (name) {
+        if (this.mainService) return this.mainService;
+        if (this.actAsBulb) return this.createLightBulb(name);
+        return new Service.Switch(name);
+    }
+
+    delaySwitch.prototype.createLightBulb = function (name) {
+        const service = new Service.Lightbulb(name);
+
+        service.getCharacteristic(Characteristic.Brightness)
+            .on('get', cb => cb(null, this.brightness))
+            .on('set', this.setBrightness.bind(this));
+
+        return service;
+    }
 
     this.getSensorState = () => {
         state = this.sensorTriggered
@@ -46,18 +61,16 @@ delaySwitch.prototype.getServices = function () {
         .setCharacteristic(Characteristic.Model, `Delay-${this.delay}ms`)
         .setCharacteristic(Characteristic.SerialNumber, this.uuid);
 
+    this.mainService = this.createMainService(this.name);
 
-    this.switchService = new Service.Switch(this.name);
-
-
-    this.switchService.getCharacteristic(Characteristic.On)
+    this.mainService.getCharacteristic(Characteristic.On)
         .on('get', this.getOn.bind(this))
         .on('set', this.setOn.bind(this));
 
     if (this.startOnReboot)
-        this.switchService.setCharacteristic(Characteristic.On, true)
+        this.mainService.setCharacteristic(Characteristic.On, true)
     
-    var services = [informationService, this.switchService]
+    var services = [informationService, this.mainService]
     
     if (!this.disableSensor){
         switch (this.sensorType) {
@@ -85,48 +98,77 @@ delaySwitch.prototype.getServices = function () {
     }
 
     return services;
-
 }
 
+delaySwitch.prototype.updateBrightness = function () {
+    const unit = this.delay;
+    this.timer = setTimeout(() => {
+        this.brightness = this.brightness - 1;
+
+        this.mainService.getCharacteristic(Characteristic.Brightness).updateValue(this.brightness);
+        this.log(`${this.brightness} remains`);
+
+        if (this.brightness <= 0) {
+            this.timeout();
+        } else {
+            this.updateBrightness();
+        }
+    }, unit);
+}
+
+delaySwitch.prototype.setBrightness = function (brightness, callback) {
+    this.log(`Set the Timer with ${brightness}%`);
+
+    this.brightness = brightness;
+
+    clearTimeout(this.timer);
+
+    if (0 < brightness) {
+        this.updateBrightness();
+    }
+
+    callback();
+}
+
+delaySwitch.prototype.timeout = function () {
+    this.log('Time is Up!');
+    this.mainService.getCharacteristic(Characteristic.On).updateValue(false);
+    this.switchOn = false;
+
+    if (!this.disableSensor) {
+        this.sensorTriggered = 1;
+        this.sensorService.getCharacteristic(this.sensorCharacteristic).updateValue(this.getSensorState());
+        this.log('Triggering Sensor');
+        setTimeout(function() {
+            this.sensorTriggered = 0;
+            this.sensorService.getCharacteristic(this.sensorCharacteristic).updateValue(this.getSensorState());
+        }.bind(this), 3000);
+    }
+}
 
 delaySwitch.prototype.setOn = function (on, callback) {
-
     if (!on) {
         this.log('Stopping the Timer');
-    
+
         this.switchOn = false;
         clearTimeout(this.timer);
         this.sensorTriggered = 0;
-        if (!this.disableSensor) this.sensorService.getCharacteristic(this.sensorCharacteristic).updateValue(this.getSensorState());
-
-        
-      } else {
+        if (!this.disableSensor) 
+            this.sensorService.getCharacteristic(this.sensorCharacteristic).updateValue(this.getSensorState());
+        } else {
         this.log('Starting the Timer');
         this.switchOn = true;
-    
-        clearTimeout(this.timer);
-        this.timer = setTimeout(function() {
-          this.log('Time is Up!');
-          this.switchService.getCharacteristic(Characteristic.On).updateValue(false);
-          this.switchOn = false;
-            
-          if (!this.disableSensor) {
-              this.sensorTriggered = 1;
-              this.sensorService.getCharacteristic(this.sensorCharacteristic).updateValue(this.getSensorState());
-              this.log('Triggering Sensor');
-              setTimeout(function() {
-                this.sensorTriggered = 0;
-                this.sensorService.getCharacteristic(this.sensorCharacteristic).updateValue(this.getSensorState());
-              }.bind(this), 3000);
-          }
-          
-        }.bind(this), this.delay);
-      }
-    
-      callback();
+
+        if (!this.actAsBulb) {
+            clearTimeout(this.timer);
+            this.timer = setTimeout(function () {
+                this.timeout();
+            }.bind(this), this.delay);
+        }
+    }
+
+    callback();
 }
-
-
 
 delaySwitch.prototype.getOn = function (callback) {
     callback(null, this.switchOn);

--- a/index.js
+++ b/index.js
@@ -170,15 +170,15 @@ delaySwitch.prototype.setBrightness = function (brightness, callback) {
 }
 
 delaySwitch.prototype.timeout = function () {
-    this.log('Time is Up!');
-    this.mainService.getCharacteristic(Characteristic.On).updateValue(false);
+    this.log.easyDebug('Time is Up!');
+    this.switchService.getCharacteristic(Characteristic.On).updateValue(false);
     this.switchOn = false;
 
     if (!this.disableSensor) {
         this.sensorTriggered = 1;
         this.sensorService.getCharacteristic(this.sensorCharacteristic).updateValue(this.getSensorState());
-        this.log('Triggering Sensor');
-        setTimeout(function() {
+        this.log.easyDebug('Triggering Sensor');
+        setTimeout(function () {
             this.sensorTriggered = 0;
             this.sensorService.getCharacteristic(this.sensorCharacteristic).updateValue(this.getSensorState());
         }.bind(this), 3000);
@@ -201,20 +201,7 @@ delaySwitch.prototype.setOn = function (on, callback) {
             if (this.delay > 0) {
                 this.log.easyDebug('Starting the Timer');
                 this.timer = setTimeout(function () {
-                    this.log.easyDebug('Time is Up!');
-                    this.switchService.getCharacteristic(Characteristic.On).updateValue(false);
-                    this.switchOn = false;
-
-                    if (!this.disableSensor) {
-                        this.sensorTriggered = 1;
-                        this.sensorService.getCharacteristic(this.sensorCharacteristic).updateValue(this.getSensorState());
-                        this.log.easyDebug('Triggering Sensor');
-                        setTimeout(function () {
-                            this.sensorTriggered = 0;
-                            this.sensorService.getCharacteristic(this.sensorCharacteristic).updateValue(this.getSensorState());
-                        }.bind(this), 3000);
-                    }
-
+                    this.timeout();
                 }.bind(this), this.delayTime);
             }
         }

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ module.exports = function (homebridge) {
     homebridge.registerAccessory("homebridge-delay-switch", "DelaySwitch", delaySwitch);
 }
 
+
 function delaySwitch(log, config, api) {
     let UUIDGen = api.hap.uuid;
 
@@ -26,7 +27,8 @@ function delaySwitch(log, config, api) {
     this.brightness = 0;
     this.sensorTriggered = 0;
     this.uuid = UUIDGen.generate(this.name)
-  
+
+
     switch (this.delayUnit) {
         case 's':
             this.delayTime = this.delay * 1000;
@@ -94,6 +96,7 @@ delaySwitch.prototype.getServices = function () {
         .setCharacteristic(Characteristic.SerialNumber, this.uuid);
 
     this.mainService = this.createMainService(this.name);
+
     this.mainService.getCharacteristic(Characteristic.On)
         .on('get', this.getOn.bind(this))
         .on('set', this.setOn.bind(this))
@@ -104,7 +107,7 @@ delaySwitch.prototype.getServices = function () {
     
     var services = [informationService, this.mainService]
     
-    if (!this.disableSensor){
+    if (!this.disableSensor) {
         switch (this.sensorType) {
             case 'contact':
                 this.sensorService = new Service.ContactSensor(this.name + ' Trigger');
@@ -137,7 +140,7 @@ delaySwitch.prototype.getServices = function () {
 }
 
 delaySwitch.prototype.updateBrightness = function () {
-    const unit = this.delay;
+    const unit = this.delayTime;
     this.timer = setTimeout(() => {
         this.brightness = this.brightness - 1;
 

--- a/index.js
+++ b/index.js
@@ -171,7 +171,7 @@ delaySwitch.prototype.setBrightness = function (brightness, callback) {
 
 delaySwitch.prototype.timeout = function () {
     this.log.easyDebug('Time is Up!');
-    this.switchService.getCharacteristic(Characteristic.On).updateValue(false);
+    this.mainService.getCharacteristic(Characteristic.On).updateValue(false);
     this.switchOn = false;
 
     if (!this.disableSensor) {

--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ delaySwitch.prototype.updateBrightness = function () {
         this.brightness = this.brightness - 1;
 
         this.mainService.getCharacteristic(Characteristic.Brightness).updateValue(this.brightness);
-        this.log(`${this.brightness} remains`);
+        this.log.easyDebug(`${this.brightness} remains`);
 
         if (this.brightness <= 0) {
             this.timeout();
@@ -156,7 +156,7 @@ delaySwitch.prototype.updateBrightness = function () {
 }
 
 delaySwitch.prototype.setBrightness = function (brightness, callback) {
-    this.log(`Set the Timer with ${brightness}%`);
+    this.log.easyDebug(`Set the Timer with ${brightness}%`);
 
     this.brightness = brightness;
 


### PR DESCRIPTION
This is an adjustment for #44 that updated for the latest version of this plugin and allows more flexibility.

This lets us adjusting the percentage of the lightbulb as per the number of units we want the timer to work.
When setting `"actAsBulb": true`, the delay becomes the unit (e.g. `"delay": 1000` = 1 second, `"delay": 60000` = 1 minute) that will be multiply by the percentage of the lightbulb.

This is very useful for adding timers via Siri Shortcuts that requires delay that the user choosing on each activation of the shortcut (e.g. "turn on boiler for X minuets" may differ depends on the current temperature, how long is the shower etc.)