### PR TITLE
Option to disable timer and choose timer unit (ms, seconds, minutes, hours. days). New config layout.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,6 @@ If you have no use of the sensor you can remove it by setting `"sensorType": nul
 
 * **When the delay switch receives ON command while it's already ON, the timer will restart and the sensor trigger will be delayed.**
 
-* **You can easily change the type from switch to light in Apple Home (then you will be able to set the value from 0 to 100**
-
 _________________________________________
 
 ## Support homebridge-delay-switch

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ If you don't use Homebridge UI or HOOBS, keep reading:
         {
           "accessory": "DelaySwitch",
           "name": "DelaySwitch",
-          "delay": 5000,
+          "type": "switch",
+          "delay": 5,
+          "delayUnit": "seconds",
           "sensorType": "motion",
           "flipSensorState": false,
           "startOnReboot": false
@@ -39,10 +41,13 @@ If you don't use Homebridge UI or HOOBS, keep reading:
 | -------------------------------- | --------------------------- |:--------:|:--------:|:--------:|
 | `accessory`             | always `"DelaySwitch"`               |     ✓    |     -    |  String  |
 | `name`                  | Name for your accessory              |     ✓    |     -    |  String  |
-| `delay`                 |  Delay/Timer in milliseconds         |     ✓    |     -    |  Integer |
-| `sensorType`            |  The sensor type that will trigger when the time has ended (`null` for no sensor)         |         | `"motion"` |  Integer |
-| `flipSensorState`       | Flips the trigger sensor state (close/open, detected/not detected)   |          |   `false`  |  Boolean |
+| `type`                  | Switch / Dimmer (lightbulb)          |     ✓    |  "switch"    |  String  |
 | `startOnReboot`         |  When set to `true`, the switch will be turned ON and start the timer when Homebridge restarts        |       |  `false` |  Boolean  |
+| `delay`                 |  Delay/Timer time. 0 - timer disabled |     ✓    |     0    |  Integer |
+| `delayUnit`             |  Delay unit: miliseconds / seconds / minutes / hours / days |     ✓    |     "miliseconds"    |  String |
+| `sensorType`            |  The sensor type that will trigger when the time has ended (`null` for no sensor)         |         | `null` |  String |
+| `flipSensorState`       | Flips the trigger sensor state (close/open, detected/not detected)   |          |   `false`  |  Boolean |
+
 
 ## Why do we need this Plugin?
 
@@ -58,14 +63,14 @@ Also it can be use with any device that requires a certain delay time after othe
 
 Basically, all you need to do is:
 
-1. Set the desired `delay` time in the config file (in milliseconds).
-2. The plugin will create one switch and optional sensor (motion/contact/occupancy).
+1. Set the desired `delay` time in the config file. 0 - timer disabled.
+2. The plugin will create one switch (switch or dimmer) and optional sensor (motion/contact/occupancy).
 3. Use this switch in any scene or automation.
 4. Set an automation to trigger when this switch is turned OFF or the sensor is triggered, using the Home app or another app such as the Eve app.
 
 ## Why Add a Trigger Sensor?
 
-A sensor (motion/contact/occupancy) is created for each accessory in order to be able to cancel the timer and the attached automations.
+A sensor (motion/contact/occupancy/leak) is created for each accessory in order to be able to cancel the timer and the attached automations.
 How does it works? You can set the automation to be triggered from the attached "trigger" sensor instead of the switch OFF command and therefore you can turn OFF the switch and prevent the sensor from triggering or any attached automations from executing.
 If you have no use of the sensor you can remove it by setting `"sensorType": null` to your config.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ If you don't use Homebridge UI or HOOBS, keep reading:
         {
           "accessory": "DelaySwitch",
           "name": "DelaySwitch",
-          "type": "switch",
           "startOnReboot": false,
           "delay": 5,
           "delayUnit": "miliseconds",
@@ -41,7 +40,6 @@ If you don't use Homebridge UI or HOOBS, keep reading:
 | -------------------------------- | --------------------------- |:--------:|:--------:|:--------:|
 | `accessory`             | always `"DelaySwitch"`               |     ✓    |     -    |  String  |
 | `name`                  | Name for your accessory              |     ✓    |     -    |  String  |
-| `type`                  | Switch / Dimmer (lightbulb)          |     ✓    |  "switch"    |  String  |
 | `startOnReboot`         |  When set to `true`, the switch will be turned ON and start the timer when Homebridge restarts        |       |  `false` |  Boolean  |
 | `delay`                 |  Delay/Timer time. 0 - timer disabled |     ✓    |     0    |  Integer |
 | `delayUnit`             |  Delay unit: miliseconds / seconds / minutes / hours / days |     ✓    |     "miliseconds"    |  String |
@@ -64,7 +62,7 @@ Also it can be use with any device that requires a certain delay time after othe
 Basically, all you need to do is:
 
 1. Set the desired `delay` time in the config file. 0 - timer disabled.
-2. The plugin will create one switch (switch or dimmer) and optional sensor (motion/contact/occupancy).
+2. The plugin will create one switch and optional sensor (motion/contact/occupancy/leak).
 3. Use this switch in any scene or automation.
 4. Set an automation to trigger when this switch is turned OFF or the sensor is triggered, using the Home app or another app such as the Eve app.
 
@@ -79,6 +77,8 @@ If you have no use of the sensor you can remove it by setting `"sensorType": nul
 * **When manualy turning OFF the switch, the timer will stop and the sensor will NOT be triggered.**
 
 * **When the delay switch receives ON command while it's already ON, the timer will restart and the sensor trigger will be delayed.**
+
+* **You can easily change the type from switch to light in Apple Home (then you will be able to set the value from 0 to 100**
 
 _________________________________________
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ If you don't use Homebridge UI or HOOBS, keep reading:
           "accessory": "DelaySwitch",
           "name": "DelaySwitch",
           "type": "switch",
+          "startOnReboot": false,
           "delay": 5,
-          "delayUnit": "seconds",
+          "delayUnit": "miliseconds",
           "sensorType": "motion",
-          "flipSensorState": false,
-          "startOnReboot": false
+          "flipSensorState": false
         }   
     ]
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -81,13 +81,13 @@
         {
           "type": "flex",
           "flex-flow": "row wrap",
-          "items": ["name", "startOnReboot"]
+          "items": ["name"]
         }
       ]
     },
     {
       "type": "fieldset",
-      "title": "Timer",
+      "title": "Switch",
       "description": "",
       "expandable": true,
       "expanded": false,
@@ -96,6 +96,11 @@
           "type": "flex",
           "flex-flow": "row wrap",
           "items": ["delay", "delayUnit"]
+        },
+        {
+          "type": "flex",
+          "flex-flow": "row wrap",
+          "items": ["startOnReboot"]
         }
       ]
     },

--- a/config.schema.json
+++ b/config.schema.json
@@ -49,7 +49,7 @@
             },
             "flipSensorState": {
                 "title": "Flip Sensor State",
-                "description": "Enable to flip the trigger sensor state (close/open, detected/not detected). When the option is enabled, the timer starts after turning off the switch.",
+                "description": "Enable to flip the trigger sensor state (close/open, detected/not detected).",
                 "type": "boolean",
                 "default": false,
                 "required": false

--- a/config.schema.json
+++ b/config.schema.json
@@ -13,17 +13,6 @@
                 "type": "string",
                 "required": true
             },
-            "type": {
-                "title": "Accessory type",
-                "description": "Switch / Dimmer (lightbulb)",
-                "type": "string",
-                "default": "switch",
-                "required": true,
-                "oneOf": [
-                    { "title": "switch", "enum": ["switch"] },
-                    { "title": "dimmer", "enum": ["dimmer"] }
-                ]
-                },
             "delay": {
                 "title": "Delay Time",
                 "description": "Delay to wait until the switch will be turned OFF. Each activation of the switch will reactivate timer (time will start to run again). 0 - timer disabled.",
@@ -97,7 +86,7 @@
         {
             "type": "flex",
             "flex-flow": "row wrap",
-            "items": ["type", "startOnReboot"]
+            "items": ["startOnReboot"]
         }
       ]
     },

--- a/config.schema.json
+++ b/config.schema.json
@@ -13,6 +13,17 @@
                 "type": "string",
                 "required": true
             },
+            "type": {
+                "title": "Accessory type",
+                "description": "Switch / Dimmer (lightbulb)",
+                "type": "string",
+                "default": "switch",
+                "required": true,
+                "oneOf": [
+                    { "title": "switch", "enum": ["switch"] },
+                    { "title": "dimmer", "enum": ["dimmer"] }
+                ]
+                },
             "delay": {
                 "title": "Delay Time",
                 "description": "Delay to wait until the switch will be turned OFF. Each start of the switch will start the timer from scratch. 0 - timer disabled.",
@@ -93,14 +104,14 @@
       "expanded": false,
       "items": [
         {
-          "type": "flex",
-          "flex-flow": "row wrap",
-          "items": ["delay", "delayUnit"]
+            "type": "flex",
+            "flex-flow": "row wrap",
+            "items": ["type", "startOnReboot"]
         },
         {
           "type": "flex",
           "flex-flow": "row wrap",
-          "items": ["startOnReboot"]
+          "items": ["delay", "delayUnit"]
         }
       ]
     },

--- a/config.schema.json
+++ b/config.schema.json
@@ -26,7 +26,7 @@
                 },
             "delay": {
                 "title": "Delay Time",
-                "description": "Delay to wait until the switch will be turned OFF. Each start of the switch will start the timer from scratch. 0 - timer disabled.",
+                "description": "Delay to wait until the switch will be turned OFF. Each activation of the switch will reactivate timer (time will start to run again). 0 - timer disabled.",
                 "type": "integer",
                 "default": 5000,
                 "required": true
@@ -47,9 +47,9 @@
             },
             "sensorType": {
                 "title": "Trigger Sensor Type",
-                "description": "The sensor type that will trigger when the time has ended (\"None\" for no sensor, \"Motion Sensor\" is default)",
+                "description": "Add an optional sensor that will be activated when the timer comes to an end.",
                 "type": "string",
-                "default": "motion",
+                "default": "",
                 "required": false,
                 "oneOf": [
                   { "title": "Motion Sensor", "enum": ["motion"] },
@@ -60,21 +60,21 @@
             },
             "flipSensorState": {
                 "title": "Flip Sensor State",
-                "description": "Enable to flip the trigger sensor state (close/open, detected/not detected). When the option is enabled, the timer starts after turning off the switch.",
+                "description": "Enable to flip the trigger sensor state (close/open, detected/not detected).",
                 "type": "boolean",
                 "default": false,
                 "required": false
             },
             "startOnReboot": {
                 "title": "Turn ON when Homebridge Restarts",
-                "description": "When Enabled, the switch will be turned ON when HomeBridge server restarts.",
+                "description": "Activate switch after Homebridge restart.",
                 "type": "boolean",
                 "default": false,
                 "required": false
             },
             "debug": {
               "title": "Enable Debug Logs",
-              "description": "When checked, the plugin will produce extra logs for debugging purposes",
+              "description": "Produce extra logs for debugging purposes",
               "type": "boolean",
               "default": false,
               "required": false

--- a/config.schema.json
+++ b/config.schema.json
@@ -14,11 +14,25 @@
                 "required": true
             },
             "delay": {
-                "title": "Delay Time in Milliseconds",
-                "description": "Amount of time in milliseconds to wait since the switch is turned ON until the switch will be turned OFF and the sensor will trigger",
+                "title": "Delay Time",
+                "description": "Delay to wait until the switch will be turned OFF. Each start of the switch will start the timer from scratch. 0 - disabled",
                 "type": "integer",
                 "default": 5000,
                 "required": true
+            },
+            "delayUnit": {
+            "title": "Delay unit",
+            "description": "Delay unit: miliseconds, seconds, minutes, hour, days.",
+            "type": "string",
+            "default": "motion",
+            "required": true,
+            "oneOf": [
+                { "title": "miliseconds", "enum": ["miliseconds"] },
+                { "title": "seconds", "enum": ["seconds"] },
+                { "title": "minutes", "enum": ["minutes"] },
+                { "title": "hours", "enum": ["hours"] },
+                { "title": "days", "enum": ["days"] }
+            ]
             },
             "sensorType": {
                 "title": "Trigger Sensor Type",
@@ -35,14 +49,14 @@
             },
             "flipSensorState": {
                 "title": "Flip Sensor State",
-                "description": "Enable to flip the trigger sensor state (close/open, detected/not detected)",
+                "description": "Enable to flip the trigger sensor state (close/open, detected/not detected). When the option is enabled, the timer starts after turning off the switch.",
                 "type": "boolean",
                 "default": false,
                 "required": false
             },
             "startOnReboot": {
                 "title": "Turn ON when Homebridge Restarts",
-                "description": "When Enabled, the switch will be turned ON and start the timer when HomeBridge server restarts",
+                "description": "When Enabled, the switch will be turned ON when HomeBridge server restarts.",
                 "type": "boolean",
                 "default": false,
                 "required": false

--- a/config.schema.json
+++ b/config.schema.json
@@ -15,7 +15,7 @@
             },
             "delay": {
                 "title": "Delay Time",
-                "description": "Delay to wait until the switch will be turned OFF. Each start of the switch will start the timer from scratch. 0 - disabled",
+                "description": "Delay to wait until the switch will be turned OFF. Each start of the switch will start the timer from scratch. 0 - timer disabled.",
                 "type": "integer",
                 "default": 5000,
                 "required": true
@@ -24,7 +24,7 @@
             "title": "Delay unit",
             "description": "Delay unit: miliseconds, seconds, minutes, hour, days.",
             "type": "string",
-            "default": "motion",
+            "default": "miliseconds",
             "required": true,
             "oneOf": [
                 { "title": "miliseconds", "enum": ["miliseconds"] },

--- a/config.schema.json
+++ b/config.schema.json
@@ -93,21 +93,21 @@
           "type": "flex",
           "flex-flow": "row wrap",
           "items": ["name"]
+        },
+        {
+            "type": "flex",
+            "flex-flow": "row wrap",
+            "items": ["type", "startOnReboot"]
         }
       ]
     },
     {
       "type": "fieldset",
-      "title": "Switch",
+      "title": "Timer",
       "description": "",
       "expandable": true,
       "expanded": false,
       "items": [
-        {
-            "type": "flex",
-            "flex-flow": "row wrap",
-            "items": ["type", "startOnReboot"]
-        },
         {
           "type": "flex",
           "flex-flow": "row wrap",
@@ -117,7 +117,7 @@
     },
     {
       "type": "fieldset",
-      "title": "Sensor",
+      "title": "Additional Sensor",
       "description": "",
       "expandable": true,
       "expanded": false,

--- a/config.schema.json
+++ b/config.schema.json
@@ -49,7 +49,7 @@
             },
             "flipSensorState": {
                 "title": "Flip Sensor State",
-                "description": "Enable to flip the trigger sensor state (close/open, detected/not detected).",
+                "description": "Enable to flip the trigger sensor state (close/open, detected/not detected). When the option is enabled, the timer starts after turning off the switch.",
                 "type": "boolean",
                 "default": false,
                 "required": false
@@ -69,5 +69,63 @@
               "required": false
             }
         }
+    },
+    "layout": [  
+    {
+      "type": "fieldset",
+      "title": "Basic settings",
+      "description": "",
+      "expandable": true,
+      "expanded": true,
+      "items": [
+        {
+          "type": "flex",
+          "flex-flow": "row wrap",
+          "items": ["name", "startOnReboot"]
+        }
+      ]
+    },
+    {
+      "type": "fieldset",
+      "title": "Timer",
+      "description": "",
+      "expandable": true,
+      "expanded": false,
+      "items": [
+        {
+          "type": "flex",
+          "flex-flow": "row wrap",
+          "items": ["delay", "delayUnit"]
+        }
+      ]
+    },
+    {
+      "type": "fieldset",
+      "title": "Sensor",
+      "description": "",
+      "expandable": true,
+      "expanded": false,
+      "items": [
+        {
+          "type": "flex",
+          "flex-flow": "row wrap",
+          "items": ["sensorType", "flipSensorState"]
+        }
+      ]
+    },
+    {
+      "type": "fieldset",
+      "title": "Logs",
+      "description": "",
+      "expandable": true,
+      "expanded": false,
+      "items": [
+        {
+          "type": "flex",
+          "flex-flow": "row wrap",
+          "items": ["debug"]
+        }
+      ]
     }
+  ]
   }

--- a/index.js
+++ b/index.js
@@ -118,26 +118,27 @@ delaySwitch.prototype.setOn = function (on, callback) {
 
         
       } else {
-        this.log.easyDebug('Starting the Timer');
         this.switchOn = true;
-    
         clearTimeout(this.timer);
-        this.timer = setTimeout(function() {
-          this.log.easyDebug('Time is Up!');
-          this.switchService.getCharacteristic(Characteristic.On).updateValue(false);
-          this.switchOn = false;
-            
-          if (!this.disableSensor) {
-              this.sensorTriggered = 1;
-              this.sensorService.getCharacteristic(this.sensorCharacteristic).updateValue(this.getSensorState());
-              this.log.easyDebug('Triggering Sensor');
-              setTimeout(function() {
-                this.sensorTriggered = 0;
-                this.sensorService.getCharacteristic(this.sensorCharacteristic).updateValue(this.getSensorState());
-              }.bind(this), 3000);
-          }
-          
-        }.bind(this), this.delay);
+        if (this.delay > 0) {
+            this.log.easyDebug('Starting the Timer');
+            this.timer = setTimeout(function() {
+              this.log.easyDebug('Time is Up!');
+              this.switchService.getCharacteristic(Characteristic.On).updateValue(false);
+              this.switchOn = false;
+                
+              if (!this.disableSensor) {
+                  this.sensorTriggered = 1;
+                  this.sensorService.getCharacteristic(this.sensorCharacteristic).updateValue(this.getSensorState());
+                  this.log.easyDebug('Triggering Sensor');
+                  setTimeout(function() {
+                    this.sensorTriggered = 0;
+                    this.sensorService.getCharacteristic(this.sensorCharacteristic).updateValue(this.getSensorState());
+                  }.bind(this), 3000);
+              }
+              
+            }.bind(this), this.delay);
+        }
       }
     
       callback();

--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@ function delaySwitch(log, config, api) {
 
     this.log = log;
     this.name = config['name'];
-    this.type = config['type'] || "switch";
     this.delay = config['delay'] || 0;
     this.delayUnit = config['delayUnit'] || "miliseconds";
     this.newDelay = config['delay'] || 0;
@@ -60,22 +59,12 @@ delaySwitch.prototype.getServices = function () {
         .setCharacteristic(Characteristic.Model, `Delay-${this.delay}-${this.delayUnit}`)
         .setCharacteristic(Characteristic.SerialNumber, this.uuid);
 
-    if (this.type == 'switch') {
-        this.switchService = new Service.Switch(this.name);
-        this.switchService.getCharacteristic(Characteristic.On)
-            .on('get', this.getOn.bind(this))
-            .on('set', this.setOn.bind(this));
-    }
-    else {
-        this.switchService = new Service.Lightbulb(this.name);
-        this.switchService.getCharacteristic(Characteristic.On)
-            //.on('get', this.getOn.bind(this))
-            .on('set', this.setOn.bind(this));
-        this.switchService.getCharacteristic(Characteristic.Brightness)
-            //.on('get', this.getOn.bind(this))
-            .on('set', this.setOn.bind(this));
-    } 
-
+   
+    this.switchService = new Service.Switch(this.name);
+    this.switchService.getCharacteristic(Characteristic.On)
+        .on('get', this.getOn.bind(this))
+        .on('set', this.setOn.bind(this));
+    
     if (this.startOnReboot)
         this.switchService.setCharacteristic(Characteristic.On, true)
     

--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ function delaySwitch(log, config, api) {
     this.log = log;
     this.name = config['name'];
     this.delay = config['delay'] || 0;
-    this.delayUnit = config['delay'] || "miliseconds";
+    this.delayUnit = config['delayUnit'] || "miliseconds";
+    this.newDelay = config['delay'] || 0;
     this.debug = config.debug || false
     this.sensorType = config['sensorType'];
     if (typeof this.sensorType === 'undefined')
@@ -57,7 +58,7 @@ delaySwitch.prototype.getServices = function () {
 
     informationService
         .setCharacteristic(Characteristic.Manufacturer, "Delay Switch")
-        .setCharacteristic(Characteristic.Model, `Delay-${this.delay}ms`)
+        .setCharacteristic(Characteristic.Model, `Delay-${this.delay}-${this.delayUnit}`)
         .setCharacteristic(Characteristic.SerialNumber, this.uuid);
 
 
@@ -122,6 +123,28 @@ delaySwitch.prototype.setOn = function (on, callback) {
         this.switchOn = true;
         clearTimeout(this.timer);
         if (this.delay > 0) {
+
+            switch (this.delayUnit) {
+                case 'miliseconds':
+                    this.newDelay = this.delay;
+                    break;
+                case 'seconds':
+                    this.newDelay = this.delay * 1000;
+                    break;
+                case 'minutes':
+                    this.newDelay = this.delay * 60 * 1000;
+                    break;
+                case 'hours':
+                    this.newDelay = this.delay * 60 * 60 * 1000;
+                    break;
+                case 'days':
+                    this.newDelay = this.delay * 24 * 60 * 60 * 1000 ;
+                    break;
+                default:
+                    this.newDelay = this.delay;
+                    break;
+            }
+    
             this.log.easyDebug('Starting the Timer');
             this.timer = setTimeout(function() {
               this.log.easyDebug('Time is Up!');
@@ -138,7 +161,7 @@ delaySwitch.prototype.setOn = function (on, callback) {
                   }.bind(this), 3000);
               }
               
-            }.bind(this), this.delay);
+            }.bind(this), this.newDelay);
         }
       }
     

--- a/index.js
+++ b/index.js
@@ -14,14 +14,15 @@ function delaySwitch(log, config, api) {
 
     this.log = log;
     this.name = config['name'];
-    this.delay = config['delay'];
+    this.delay = config['delay'] || 0;
+    this.delayUnit = config['delay'] || "miliseconds";
     this.debug = config.debug || false
     this.sensorType = config['sensorType'];
     if (typeof this.sensorType === 'undefined')
         this.sensorType = 'motion'
     this.flipSensor = config['flipSensorState'];
     this.disableSensor = config['disableSensor'] || !config['sensorType'];
-    this.startOnReboot = config['startOnReboot'];
+    this.startOnReboot = config['startOnReboot'] || false;
     this.timer;
     this.switchOn = false;
     this.sensorTriggered = 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-delay-switch",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-delay-switch",
-      "version": "3.1.1",
+      "version": "3.2.0",
       "funding": [
         {
           "type": "paypal",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-delay-switch",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "Delay switches for Homebridge",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
- Option to disable timer - when set delay to 0.
- Option to choose timer unit (ms, seconds, minutes, hours. days) - new option in config.
- In model display, delay unit, instead of "ms".
- new config layout with sections:

<img width="792" alt="Zrzut ekranu 2023-12-18 o 16 21 45" src="https://github.com/nitaybz/homebridge-delay-switch/assets/82271669/c44df4cb-5a1a-4753-8c7f-6f64fbe0f414">


- update version to 3.2.0
- update readme
