### PR TITLE
startOnReboot behaviour restored. Improved config schema

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -38,9 +38,10 @@
                 "title": "Trigger Sensor Type",
                 "description": "Adds an optional sensor that will be activated when the timer comes to an end.",
                 "type": "string",
-                "default": "motion",
-                "required": false,
+                "default": "none",
+                "required": true,
                 "oneOf": [
+                  { "title": "None", "enum": ["none"] },
                   { "title": "Motion Sensor", "enum": ["motion"] },
                   { "title": "Contact Sensor", "enum": ["contact"] },
                   { "title": "Occupancy Sensor", "enum": ["occupancy"] },

--- a/index.js
+++ b/index.js
@@ -18,8 +18,10 @@ function delaySwitch(log, config, api) {
 	this.sensorType = config['sensorType']
 	if (typeof this.sensorType === 'undefined')
 		this.sensorType = 'motion'
+	if(this.sensorType == 'none')
+		this.sensorType = 'motion' // map none to motion, but disable the sensor	
 	this.flipSensor = config['flipSensorState']
-	this.disableSensor = config['disableSensor'] || !config['sensorType'] || this.delay === 0
+	this.disableSensor = config['disableSensor'] || !config['sensorType'] || config['sensorType'] == 'none' || this.delay === 0
 	this.startOnReboot = config['startOnReboot'] || false
 	this.switchOn = false
 	this.sensorTriggered = 0
@@ -83,6 +85,9 @@ delaySwitch.prototype.getServices = function () {
 		.on('set', this.setOn.bind(this))
 		.updateValue(this.startOnReboot)
 
+	if (this.startOnReboot)
+		this.switchService.setCharacteristic(Characteristic.On, true)
+
 	var services = [informationService, this.switchService]
 
 	if (!this.disableSensor) {
@@ -136,6 +141,7 @@ delaySwitch.prototype.setOn = function (value, callback) {
 				this.log.easyDebug('Time is Up!')
 				this.switchService.getCharacteristic(Characteristic.On).updateValue(false)
 				this.switchOn = false
+				this.switchService.setCharacteristic(Characteristic.On, false)
 
 				if (!this.disableSensor) {
 					this.sensorTriggered = 1


### PR DESCRIPTION
Added a 'none' sensor type to schema to allow modification of configuration within UI without the user inadvertently adding a sensor to a delay switch specifically configured without one.

Added setCharacteristic call to set the state of 'On' both on start up (if configured) and on delay timeout forcing event notifications.